### PR TITLE
Allow the flock for kernel builds

### DIFF
--- a/ui/build/paths/config.go
+++ b/ui/build/paths/config.go
@@ -84,6 +84,7 @@ var Configuration = map[string]PathConfig{
 	"egrep":    Allowed,
 	"expr":     Allowed,
 	"find":     Allowed,
+	"flock":    Allowed,
 	"fuser":    Allowed,
 	"getopt":   Allowed,
 	"git":      Allowed,


### PR DESCRIPTION
requires for kernels which has wireguard
and its common having kernels with wireguard. so allow it, what are you waiting for?

Signed-off-by: Jyotiraditya <dreadnaught02@outlook.com>
Change-Id: I4ef18f857c27df99b1f262ab8bd54e1d44549298