### PR TITLE
soong: java: ApexName is renamed to ApexVariationName

### DIFF
--- a/java/java.go
+++ b/java/java.go
@@ -1683,7 +1683,7 @@ func (j *Module) compile(ctx android.ModuleContext, aaptSrcJar android.Path) {
 		j.linter.compileSdkVersion = lintSDKVersionString(j.sdkVersion())
 		j.linter.javaLanguageLevel = flags.javaVersion.String()
 		j.linter.kotlinLanguageLevel = "1.3"
-		if j.ApexName() != "" && ctx.Config().UnbundledBuild() {
+		if j.ApexVariationName() != "" && ctx.Config().UnbundledBuild() {
 			j.linter.buildModuleReportZip = true
 		}
 		j.linter.lint(ctx)


### PR DESCRIPTION
It was renamed to ApexVariationName in preparation for reusing the same
variation for multiple apexes, rename ApexName to ApexVariationName.

fixes:
build/soong/java/java.go:1686:7: j.ApexName undefined (type *Module has no field or method ApexName)