### PR TITLE
Disable compound-token-split-by-macro warning

### DIFF
--- a/cc/config/clang.go
+++ b/cc/config/clang.go
@@ -144,6 +144,7 @@ func init() {
 
 		// Warnings from clang-12
 		"-Wno-gnu-folding-constant",
+		"-Wno-compound-token-split-by-macro",
 
 		// Calls to the APIs that are newer than the min sdk version of the caller should be
 		// guarded with __builtin_available.


### PR DESCRIPTION
hardware/qcom/camera/msm8998/QCamera2 generates too many of these
warnings, and we don't care about fixing them for a legacy device.

Change-Id: I288cdbf3cef027c9e50bbe01565a9ef6ebb6bd4b
Signed-off-by: Dmitrii <bankersenator@gmail.com>
Signed-off-by: Pranav Temkar <pranavtemkar@gmail.com>